### PR TITLE
Update composer dependencies and clean up polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,11 @@
         "php": "^8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "ext-json": "*",
         "cmfcmf/openweathermap-php-api": "^3.2",
         "nyholm/psr7": "^1.8",
         "symfony/console": "^7.1",
         "symfony/dotenv": "^7.1",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^2",
         "symfony/framework-bundle": "^7.1",
         "symfony/http-client": "^7.1",
         "symfony/property-access": "^7.1",
@@ -38,13 +37,14 @@
         }
     },
     "replace": {
-        "paragonie/random_compat": "2.*",
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-iconv": "*",
-        "symfony/polyfill-php72": "*",
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php56": "*"
+        "symfony/polyfill-php83": "*",
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php73": "*",
+        "symfony/polyfill-php72": "*"
     },
     "scripts": {
         "auto-scripts": {


### PR DESCRIPTION
## Summary
- Entfernt `ext-json` Requirement (seit PHP 8.0 immer verfügbar)
- Aktualisiert `symfony/flex` von `^1.3.1` auf `^2`
- Bereinigt `replace`-Sektion: entfernt obsoletes `paragonie/random_compat` und alte PHP-5.6/7.0/7.1-Polyfills, fügt PHP-7.2 bis 8.3-Polyfills passend zur Mindest-PHP-Version hinzu

## Test plan
- [ ] `composer validate` ausführen
- [ ] `composer update` ausführen und prüfen, dass alle Abhängigkeiten aufgelöst werden
- [ ] Anwendung testen

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)