### PR TITLE
Upgrade Symfony from 7.1 to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
         "ext-iconv": "*",
         "cmfcmf/openweathermap-php-api": "^3.2",
         "nyholm/psr7": "^1.8",
-        "symfony/console": "^7.1",
-        "symfony/dotenv": "^7.1",
+        "symfony/console": "^8.0",
+        "symfony/dotenv": "^8.0",
         "symfony/flex": "^2",
-        "symfony/framework-bundle": "^7.1",
-        "symfony/http-client": "^7.1",
-        "symfony/property-access": "^7.1",
-        "symfony/serializer": "^7.1",
-        "symfony/yaml": "^7.1"
+        "symfony/framework-bundle": "^8.0",
+        "symfony/http-client": "^8.0",
+        "symfony/property-access": "^8.0",
+        "symfony/serializer": "^8.0",
+        "symfony/yaml": "^8.0"
     },
     "config": {
         "optimize-autoloader": true,
@@ -65,7 +65,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "^7.1"
+            "require": "^8.0"
         }
     }
 }

--- a/src/Command/UpdateWeatherCommand.php
+++ b/src/Command/UpdateWeatherCommand.php
@@ -7,6 +7,7 @@ use App\Entity\Weather;
 use App\ForecastRetriever\WeatherForecastRetrieverInterface;
 use App\RideRetriever\RideRetrieverInterface;
 use App\WeatherPusher\WeatherPusherInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,6 +16,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 
+#[AsCommand(
+    name: 'criticalmass:weather:update',
+    description: 'Retrieve weather forecasts for parameterized range',
+)]
 class UpdateWeatherCommand extends Command
 {
     public function __construct(
@@ -28,8 +33,6 @@ class UpdateWeatherCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('criticalmass:weather:update')
-            ->setDescription('Retrieve weather forecasts for parameterized range')
             ->addArgument(
                 'from',
                 InputArgument::OPTIONAL,

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -3,36 +3,9 @@
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
-
-    protected function configureContainer(ContainerConfigurator $container): void
-    {
-        $container->import('../config/{packages}/*.yaml');
-        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
-
-        if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
-            $container->import('../config/{services}.yaml');
-            $container->import('../config/{services}_'.$this->environment.'.yaml');
-        } elseif (is_file($path = \dirname(__DIR__).'/config/services.php')) {
-            (require $path)($container->withPath($path), $this);
-        }
-    }
-
-    protected function configureRoutes(RoutingConfigurator $routes): void
-    {
-        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
-        $routes->import('../config/{routes}/*.yaml');
-
-        if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
-            $routes->import('../config/{routes}.yaml');
-        } elseif (is_file($path = \dirname(__DIR__).'/config/routes.php')) {
-            (require $path)($routes->withPath($path), $this);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Alle `symfony/*`-Pakete von `^7.1` auf `^8.0` aktualisiert
- `extra.symfony.require` auf `^8.0` gesetzt
- `Kernel.php` vereinfacht: redundante `configureContainer()` und `configureRoutes()` Overrides entfernt (MicroKernelTrait-Defaults reichen aus)
- `UpdateWeatherCommand` modernisiert: `#[AsCommand]`-Attribut statt veralteter `setName()`/`setDescription()`-Aufrufe

## Test plan
- [ ] `composer update` ausführen und sicherstellen, dass Symfony 8 korrekt aufgelöst wird
- [ ] Symfony-Upgrade-Guide auf weitere Breaking Changes prüfen
- [ ] `bin/console criticalmass:weather:update` testen
- [ ] `bin/console list` prüfen, ob Command korrekt registriert ist

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)